### PR TITLE
Fix nfs plugin implementation for NetBSD

### DIFF
--- a/src/nfs.c
+++ b/src/nfs.c
@@ -622,19 +622,14 @@ static int nfs_read(void) {
 
   /* NetBSD reports v2 statistics mapped to v3 and doen't yet support v4 */
   if (report_v2) {
-    if (!suppress_warning) {
-      WARNING(
-          "nfs plugin: NFSv2 statistics have been requested "
-          "but they are mapped to NFSv3 statistics in the kernel on NetBSD.");
-    }
+    WARNING("nfs plugin: NFSv2 statistics have been requested "
+            "but they are mapped to NFSv3 statistics in the kernel on NetBSD.");
     return 0;
   }
 
   if (report_v4) {
-    if (!suppress_warning) {
-      WARNING("nfs plugin: NFSv4 statistics have been requested "
-              "but they are not yet supported on NetBSD.");
-    }
+    WARNING("nfs plugin: NFSv4 statistics have been requested "
+            "but they are not yet supported on NetBSD.");
     return 0;
   }
 


### PR DESCRIPTION
Remove use of undefined `suppress_warning` variable.

The modification of my original [PR#3333](https://github.com/collectd/collectd/pull/3333) via [PR#3377](https://github.com/collectd/collectd/pull/3377) introduced the use of a `suppress_warning` variable which is undefined in NetBSD context.